### PR TITLE
Add isset to $attributes['name'] call to prevent error when attribute…

### DIFF
--- a/src/Traits/Messagable.php
+++ b/src/Traits/Messagable.php
@@ -129,7 +129,7 @@ trait Messagable
      */
     public function getNameAttribute()
     {
-        if($this->attributes['name'])
+        if(isset($this->attributes['name']))
             return $this->attributes['name'];
         
         if($this->username)


### PR DESCRIPTION
… is missing.